### PR TITLE
Finalize V2.0.1 release hardening

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,6 +2,7 @@ name: Build Windows Artifacts
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build-windows:
@@ -28,7 +29,7 @@ jobs:
           python -m pip install -c constraints/release-2.0.1.txt . pyinstaller
 
       - name: Compile source and tests
-        run: python -m compileall prog.py src tests
+        run: python -m compileall prog.py src tests scripts/collect_third_party_licenses.py
 
       - name: Run deterministic tests
         run: python -m unittest discover -s tests
@@ -67,20 +68,72 @@ jobs:
             Copy-Item -LiteralPath $source -Destination $target -Force
           }
 
-      - name: Verify packaged executable
+      - name: Collect exact third-party licenses
         shell: pwsh
         run: |
-          $exe = "dist\$env:APP_DIR\GoogleScholarScraper.exe"
+          $ErrorActionPreference = "Stop"
+          $appDir = "dist\$env:APP_DIR"
+          python scripts\collect_third_party_licenses.py `
+            --constraints constraints\release-2.0.1.txt `
+            --app-dir $appDir `
+            --output-dir "$appDir\third_party_licenses"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Third-party license collection failed with exit code $LASTEXITCODE."
+          }
+
+      - name: Verify packaged executable and distribution compliance
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $appDir = "dist\$env:APP_DIR"
+          $exe = "$appDir\GoogleScholarScraper.exe"
           if (-not (Test-Path -LiteralPath $exe)) {
             throw "Expected packaged executable missing: $exe"
           }
+
           foreach ($name in @("LICENSE", "NOTICE", "COMMERCIAL_LICENSE.md", "THIRD_PARTY_NOTICES.txt")) {
-            $path = Join-Path "dist\$env:APP_DIR" $name
+            $path = Join-Path $appDir $name
             if (-not (Test-Path -LiteralPath $path)) {
               throw "Required distribution notice missing: $path"
             }
+            $duplicate = Join-Path "$appDir\_internal" $name
+            if (Test-Path -LiteralPath $duplicate) {
+              throw "Distribution notice must not be duplicated inside _internal: $duplicate"
+            }
           }
-          $unexpected = Get-ChildItem -LiteralPath "dist\$env:APP_DIR\_internal" -Directory -ErrorAction SilentlyContinue |
+
+          $licenseRoot = Join-Path $appDir "third_party_licenses"
+          $requiredEntries = @(
+            "MANIFEST.txt",
+            "beautifulsoup4",
+            "soupsieve",
+            "openpyxl",
+            "et-xmlfile",
+            "requests",
+            "urllib3",
+            "charset-normalizer",
+            "idna",
+            "certifi",
+            "typing-extensions",
+            "pyinstaller",
+            "pyinstaller-hooks-contrib",
+            "python",
+            "tcl-tk"
+          )
+          foreach ($entry in $requiredEntries) {
+            $path = Join-Path $licenseRoot $entry
+            if (-not (Test-Path -LiteralPath $path)) {
+              throw "Required third-party license bundle entry missing: $path"
+            }
+          }
+
+          $legalFiles = Get-ChildItem -LiteralPath $licenseRoot -File -Recurse |
+            Where-Object { $_.Name -ne "MANIFEST.txt" }
+          if (-not $legalFiles) {
+            throw "Third-party license bundle contains no legal files."
+          }
+
+          $unexpected = Get-ChildItem -LiteralPath "$appDir\_internal" -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -like "h2-*.dist-info" -or $_.Name -like "hpack-*.dist-info" -or $_.Name -like "hyperframe-*.dist-info" }
           if ($unexpected) {
             throw "Unexpected optional HTTP/2 metadata found: $($unexpected.Name -join ', ')"
@@ -116,6 +169,7 @@ jobs:
           if (-not $iscc) {
             throw "Inno Setup compiler was not found."
           }
+          & $iscc /?
           "ISCC=$iscc" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Build Windows Installer
@@ -175,6 +229,12 @@ jobs:
             $path = Join-Path $installRoot $name
             if (-not (Test-Path -LiteralPath $path)) {
               throw "Installed distribution notice missing: $path"
+            }
+          }
+          foreach ($entry in @("MANIFEST.txt", "requests", "urllib3", "idna", "python", "tcl-tk")) {
+            $path = Join-Path (Join-Path $installRoot "third_party_licenses") $entry
+            if (-not (Test-Path -LiteralPath $path)) {
+              throw "Installed third-party license bundle entry missing: $path"
             }
           }
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,6 +3,9 @@ name: Build Windows Artifacts
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build-windows:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -172,7 +172,6 @@ jobs:
           if (-not $iscc) {
             throw "Inno Setup compiler was not found."
           }
-          & $iscc /?
           "ISCC=$iscc" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Build Windows Installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@
 
 ### Changed
 
-- Added exact V2.0.1 release-candidate dependency constraints.
-- Added root-level third-party notices for the expected Windows distribution dependency set.
-- Included `LICENSE`, `NOTICE`, `COMMERCIAL_LICENSE.md`, and `THIRD_PARTY_NOTICES.txt` in PyInstaller portable and installer layouts.
+- Added exact V2.0.1 release-build dependency constraints.
+- Updated constrained HTTP dependencies to `requests 2.33.0`, `urllib3 2.7.0`, and `idna 3.15` following the final dependency security review.
+- Added deterministic collection of exact third-party legal files from the constrained release-build environment.
+- Included `LICENSE`, `NOTICE`, `COMMERCIAL_LICENSE.md`, `THIRD_PARTY_NOTICES.txt`, and a populated `third_party_licenses/` bundle in portable and installer layouts.
+- Removed duplicate project notice files from the PyInstaller `_internal` directory.
 - Added remote Windows installer install-launch-export-uninstall smoke coverage.
-- Improved project metadata for package consumers and repository presentation.
+- Added verification of the installed third-party license bundle.
+- Improved project metadata and release documentation.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Added exact V2.0.1 release-build dependency constraints.
 - Updated constrained HTTP dependencies to `requests 2.33.0`, `urllib3 2.7.0`, and `idna 3.15` following the final dependency security review.
+- Raised the declared Requests runtime floor to `requests>=2.33,<3`.
 - Added deterministic collection of exact third-party legal files from the constrained release-build environment.
 - Included `LICENSE`, `NOTICE`, `COMMERCIAL_LICENSE.md`, `THIRD_PARTY_NOTICES.txt`, and a populated `third_party_licenses/` bundle in portable and installer layouts.
 - Removed duplicate project notice files from the PyInstaller `_internal` directory.

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -16,6 +16,7 @@ Examples of uses that may require a separate commercial license include:
 - Using the software as a commercial product component where the license requires separate permission.
 
 This document does not grant commercial rights, set fixed prices, or create
-automatic approval conditions. Contact Mahdi Navaei for commercial licensing,
-sponsorship, integration, or custom collaboration inquiries:
-M.Navaei1367@gmail.com
+automatic approval conditions.
+
+For commercial licensing, sponsorship, integration, or custom collaboration
+inquiries, contact [Mahdi Navaei](mailto:M.Navaei1367@gmail.com).

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ configured to install or locate Inno Setup and fail if the installer cannot be
 built.
 
 Portable and installer distributions include `LICENSE`, `NOTICE`,
-`COMMERCIAL_LICENSE.md`, and `THIRD_PARTY_NOTICES.txt`.
+`COMMERCIAL_LICENSE.md`, `THIRD_PARTY_NOTICES.txt`, and a generated
+`third_party_licenses/` bundle collected from the exact constrained release-build
+environment.
 
 ## Project Structure
 
@@ -256,16 +258,19 @@ tests/
 
 packaging/pyinstaller/    PyInstaller configuration
 installer/                Inno Setup definition
-scripts/                  Windows build helper
+scripts/                  Windows build and release-compliance helpers
+constraints/              Exact release-build dependency constraints
 docs/                     Release and audit documentation
 ```
 
 ## Release And Documentation
 
-- [Release notes](docs/RELEASE_NOTES_V2.0.0.md)
-- [V2 release verification record](docs/V2_RELEASE_CHECKLIST.md)
+- [V2.0.1 release notes](docs/RELEASE_NOTES_V2.0.1.md)
+- [V2.0.0 release notes](docs/RELEASE_NOTES_V2.0.0.md)
+- [V2.0.0 release verification record](docs/V2_RELEASE_CHECKLIST.md)
 - [Changelog](CHANGELOG.md)
 - [Third-party notices](THIRD_PARTY_NOTICES.txt)
+- [Third-party license bundle workflow](third_party_licenses/README.md)
 - [PyInstaller spec](packaging/pyinstaller/GoogleScholarScraper.spec)
 - [Inno Setup definition](installer/GoogleScholarScraper.iss)
 - [Windows build script](scripts/build_windows.ps1)

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,8 +1,10 @@
 Google Scholar Scraper Third-Party Notices
 
 This file is the distribution index for V2.0.1. Third-party components remain
-under their own licenses. License texts are preserved in the release bundle
-under third_party_licenses/.
+under their own licenses. The Windows portable and installer distributions
+include the corresponding legal files under third_party_licenses/ together
+with a generated MANIFEST.txt describing the exact files collected from the
+constrained release-build environment.
 
 Runtime dependencies:
 
@@ -18,46 +20,43 @@ Runtime dependencies:
 - et-xmlfile 2.0.0
   License: MIT License
 
-- requests 2.32.5
+- requests 2.33.0
   License: Apache-2.0
 
-- urllib3 2.3.0
+- urllib3 2.7.0
   License: MIT License
 
 - charset-normalizer 3.4.4
   License: MIT License
 
-- idna 3.11
+- idna 3.15
   License: BSD-3-Clause
 
 - certifi 2025.11.12
   License: MPL-2.0
 
-Build dependencies:
-
-- PyInstaller 6.20.0
-  License: GPLv2-or-later with special exception for distributing built applications
-
-- pyinstaller-hooks-contrib 2026.4
-  License: GPL-2.0-or-later / Apache-2.0 depending on included component
-
-- altgraph 0.17.5
-  License: MIT License
-
-- packaging 25.0
-  License: Apache-2.0 OR BSD-2-Clause
-
-- pefile 2024.8.26
-  License: MIT License
-
-- pywin32-ctypes 0.2.3
-  License: BSD-3-Clause
-
 - typing_extensions 4.15.0
   License: PSF-2.0
 
+Bundled runtime and packaging components:
+
+- Python 3.10 runtime
+  License: Python Software Foundation License
+
+- Tcl/Tk runtime used by tkinter
+  License: Tcl/Tk License
+
+- PyInstaller 6.20.0
+  License: GPLv2-or-later with the PyInstaller bootloader exception permitting
+  distribution of applications built with PyInstaller
+
+- pyinstaller-hooks-contrib 2026.4
+  License: GPL-2.0-or-later / Apache-2.0 depending on the included component
+
 Release distribution requirement:
 
-The release package must include the corresponding license text files under
-third_party_licenses/ and this notice index together with LICENSE, NOTICE,
-and COMMERCIAL_LICENSE.md.
+The release package must include this notice index, LICENSE, NOTICE,
+COMMERCIAL_LICENSE.md, and a populated third_party_licenses/ directory generated
+from the exact constrained release-build environment. The generated license
+bundle is a redistribution aid and does not replace or modify any third-party
+license terms.

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,95 +1,63 @@
 Google Scholar Scraper Third-Party Notices
 
-This file summarizes third-party components expected in the V2.0.1 Windows
-portable and installer distributions. Version evidence is taken from the Python
-package metadata used for the V2.0.1 release-candidate build constraints.
-
-The application code is distributed under LICENSE, NOTICE, and
-COMMERCIAL_LICENSE.md. Third-party dependencies remain under their own licenses.
+This file is the distribution index for V2.0.1. Third-party components remain
+under their own licenses. License texts are preserved in the release bundle
+under third_party_licenses/.
 
 Runtime dependencies:
 
 - beautifulsoup4 4.14.3
   License: MIT License
-  Project: https://www.crummy.com/software/BeautifulSoup/bs4/
 
 - soupsieve 2.8.1
-  License: MIT
-  Project: https://github.com/facelessuser/soupsieve
+  License: MIT License
 
 - openpyxl 3.1.5
-  License: MIT
-  Project: https://openpyxl.readthedocs.io
+  License: MIT License
 
-- et_xmlfile 2.0.0
-  License: MIT
-  Project: https://foss.heptapod.net/openpyxl/et_xmlfile
+- et-xmlfile 2.0.0
+  License: MIT License
 
 - requests 2.32.5
   License: Apache-2.0
-  Project: https://requests.readthedocs.io
 
 - urllib3 2.3.0
-  License: MIT
-  Project: https://urllib3.readthedocs.io
+  License: MIT License
 
 - charset-normalizer 3.4.4
-  License: MIT
-  Project: https://charset-normalizer.readthedocs.io/
+  License: MIT License
 
 - idna 3.11
   License: BSD-3-Clause
-  Project: https://github.com/kjd/idna
 
 - certifi 2025.11.12
   License: MPL-2.0
-  Project: https://github.com/certifi/python-certifi
 
-Build and packaging components:
+Build dependencies:
 
 - PyInstaller 6.20.0
-  License: GPLv2-or-later with a special exception allowing distribution of
-  programs built with PyInstaller, including non-free programs.
-  Project: https://pyinstaller.org
+  License: GPLv2-or-later with special exception for distributing built applications
 
 - pyinstaller-hooks-contrib 2026.4
-  License: GPL-2.0-or-later for standard hooks and files; Apache-2.0 for
-  runtime hooks under _pyinstaller_hooks_contrib/rthooks.
-  Project: https://github.com/pyinstaller/pyinstaller-hooks-contrib
+  License: GPL-2.0-or-later / Apache-2.0 depending on included component
 
 - altgraph 0.17.5
-  License: MIT
-  Project: https://altgraph.readthedocs.io
+  License: MIT License
 
 - packaging 25.0
   License: Apache-2.0 OR BSD-2-Clause
-  Project: https://packaging.pypa.io/
 
 - pefile 2024.8.26
-  License: MIT
-  Project: https://github.com/erocarrera/pefile
+  License: MIT License
 
 - pywin32-ctypes 0.2.3
   License: BSD-3-Clause
-  Project: https://github.com/enthought/pywin32-ctypes
 
 - typing_extensions 4.15.0
   License: PSF-2.0
-  Project: https://github.com/python/typing_extensions
 
-Python and Windows UI runtime:
+Release distribution requirement:
 
-- Python 3.10 runtime
-  License: Python Software Foundation License
-  Project: https://www.python.org/
-
-- Tcl/Tk runtime used by tkinter
-  License: Tcl/Tk License
-  Project: https://www.tcl.tk/
-
-Distribution note:
-
-The PyInstaller onedir bundle may include package metadata directories and
-license files generated from installed wheels. This notice file is included at
-the top level of the portable and installer layouts so redistributors have a
-stable, human-readable third-party notice with the application license files.
+The release package must include the corresponding license text files under
+third_party_licenses/ and this notice index together with LICENSE, NOTICE,
+and COMMERCIAL_LICENSE.md.

--- a/constraints/release-2.0.1.txt
+++ b/constraints/release-2.0.1.txt
@@ -1,14 +1,15 @@
-# Exact dependency set used for the V2.0.1 release-candidate build gate.
+# Exact dependency set used for the V2.0.1 release build gate.
 # Runtime dependencies
 beautifulsoup4==4.14.3
 certifi==2025.11.12
 charset-normalizer==3.4.4
 et-xmlfile==2.0.0
-idna==3.11
+idna==3.15
 openpyxl==3.1.5
-requests==2.32.5
+requests==2.33.0
 soupsieve==2.8.1
-urllib3==2.3.0
+typing-extensions==4.15.0
+urllib3==2.7.0
 
 # Build dependencies
 altgraph==0.17.5
@@ -17,4 +18,3 @@ pefile==2024.8.26
 pyinstaller==6.20.0
 pyinstaller-hooks-contrib==2026.4
 pywin32-ctypes==0.2.3
-typing-extensions==4.15.0

--- a/docs/RELEASE_NOTES_V2.0.1.md
+++ b/docs/RELEASE_NOTES_V2.0.1.md
@@ -2,23 +2,48 @@
 
 ## Overview
 
-V2.0.1 is a hardening release focused on packaging correctness, distribution safety, release verification, and user-facing failure handling.
+V2.0.1 is a focused hardening release for packaging correctness, distribution
+notices, dependency security, release verification, and user-facing failure
+handling. It does not add new scraping capabilities or change the accepted V2
+UI design.
 
-## Changes
+## Fixed
 
-- Corrected the supported Python version declaration to Python 3.10+.
-- Added exact release dependency constraints.
-- Added third-party dependency notice tracking.
-- Improved Windows portable and installer distribution metadata.
-- Added installer lifecycle smoke validation.
-- Improved export error handling.
-- Improved partial-success wording.
+- Corrected the supported source-runtime declaration to Python 3.10+.
+- Corrected partial-success wording so preserved results are not described as
+  already exported.
+- Added safe user-facing handling for expected Excel and CSV filesystem write
+  failures.
+- Aligned local and GitHub Actions checksum entries to use plain release
+  artifact filenames.
 
-## Verification
+## Distribution And Dependency Hardening
 
-Validated with source compilation, deterministic tests, package installation,
-Windows artifact builds, installer smoke checks, and SHA-256 verification.
+- Added exact V2.0.1 release-build constraints.
+- Updated the constrained HTTP dependency set to `requests 2.33.0`,
+  `urllib3 2.7.0`, and `idna 3.15` following the final dependency security
+  review.
+- Included `LICENSE`, `NOTICE`, `COMMERCIAL_LICENSE.md`, and
+  `THIRD_PARTY_NOTICES.txt` at the distribution root.
+- Added deterministic third-party legal-file collection from the exact installed
+  release-build distributions.
+- Added a generated `third_party_licenses/MANIFEST.txt` and corresponding legal
+  files for runtime dependencies, Python, Tcl/Tk, PyInstaller, and PyInstaller
+  hooks used by the Windows distribution.
+- Removed duplicate project notice files from the PyInstaller `_internal`
+  directory.
 
-## Release Process
+## Windows Verification
 
-V2.0.1 artifacts use a separate versioned artifact set from V2.0.0.
+- Added clean installer install-launch-export-uninstall smoke validation on a
+  GitHub-hosted Windows runner.
+- Added verification that installed and portable layouts contain the required
+  project notices and populated third-party license bundle.
+- Continued packaged Excel and CSV smoke validation with Unicode data and
+  relevance-score coverage.
+
+## Release Integrity
+
+V2.0.1 uses a new versioned source commit, workflow run, Portable ZIP, Installer
+EXE, and SHA-256 checksum set. The published V2.0.0 tag, release, and assets are
+not modified by this patch release.

--- a/docs/RELEASE_NOTES_V2.0.1.md
+++ b/docs/RELEASE_NOTES_V2.0.1.md
@@ -1,0 +1,24 @@
+# Google Scholar Scraper V2.0.1 Release Notes
+
+## Overview
+
+V2.0.1 is a hardening release focused on packaging correctness, distribution safety, release verification, and user-facing failure handling.
+
+## Changes
+
+- Corrected the supported Python version declaration to Python 3.10+.
+- Added exact release dependency constraints.
+- Added third-party dependency notice tracking.
+- Improved Windows portable and installer distribution metadata.
+- Added installer lifecycle smoke validation.
+- Improved export error handling.
+- Improved partial-success wording.
+
+## Verification
+
+Validated with source compilation, deterministic tests, package installation,
+Windows artifact builds, installer smoke checks, and SHA-256 verification.
+
+## Release Process
+
+V2.0.1 artifacts use a separate versioned artifact set from V2.0.0.

--- a/docs/RELEASE_NOTES_V2.0.1.md
+++ b/docs/RELEASE_NOTES_V2.0.1.md
@@ -23,6 +23,7 @@ UI design.
 - Updated the constrained HTTP dependency set to `requests 2.33.0`,
   `urllib3 2.7.0`, and `idna 3.15` following the final dependency security
   review.
+- Raised the declared Requests runtime floor to `requests>=2.33,<3`.
 - Included `LICENSE`, `NOTICE`, `COMMERCIAL_LICENSE.md`, and
   `THIRD_PARTY_NOTICES.txt` at the distribution root.
 - Added deterministic third-party legal-file collection from the exact installed

--- a/docs/V2_RELEASE_CHECKLIST.md
+++ b/docs/V2_RELEASE_CHECKLIST.md
@@ -35,8 +35,9 @@ future tag or GitHub Release publication.
   type syntax. V2.0.1 corrects the declared minimum to Python 3.10+.
 - V2.0.0 portable and installer layouts did not include all repository license
   and notice files at the distribution root. V2.0.1 adds those files.
-- V2.0.0 did not include a consolidated third-party notices file. V2.0.1 adds
-  `THIRD_PARTY_NOTICES.txt`.
+- V2.0.0 did not include a consolidated third-party legal-file bundle. V2.0.1
+  adds a generated `third_party_licenses/` bundle assembled from the exact
+  constrained release-build environment.
 
 ## Release Governance
 

--- a/packaging/pyinstaller/GoogleScholarScraper.spec
+++ b/packaging/pyinstaller/GoogleScholarScraper.spec
@@ -6,13 +6,6 @@ from pathlib import Path
 project_root = Path(SPECPATH).parents[1]
 src_path = project_root / "src"
 entrypoint = src_path / "google_scholar_scraper" / "__main__.py"
-distribution_documents = [
-    project_root / "LICENSE",
-    project_root / "NOTICE",
-    project_root / "COMMERCIAL_LICENSE.md",
-    project_root / "THIRD_PARTY_NOTICES.txt",
-]
-datas = [(str(path), ".") for path in distribution_documents]
 excluded_optional_modules = [
     "aiohttp",
     "cryptography",
@@ -51,7 +44,7 @@ a = Analysis(
     [str(entrypoint)],
     pathex=[str(src_path)],
     binaries=[],
-    datas=datas,
+    datas=[],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "google-scholar-scraper"
 version = "2.0.1"
-description = "A lightweight desktop app for reviewing and exporting Google Scholar search results."
+description = "A lightweight Windows desktop app for collecting, ranking, reviewing, and exporting Google Scholar search results."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "beautifulsoup4>=4.14,<5",
     "openpyxl>=3.1,<4",
-    "requests>=2.32,<3",
+    "requests>=2.33,<3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -16,6 +16,8 @@ $PortablePath = Join-Path $ReleaseDir $PortableName
 $ChecksumPath = Join-Path $ReleaseDir "SHA256SUMS.txt"
 $SpecPath = Join-Path $ProjectRoot "packaging\pyinstaller\GoogleScholarScraper.spec"
 $InstallerScript = Join-Path $ProjectRoot "installer\GoogleScholarScraper.iss"
+$ConstraintsPath = Join-Path $ProjectRoot "constraints\release-2.0.1.txt"
+$LicenseCollectorPath = Join-Path $ProjectRoot "scripts\collect_third_party_licenses.py"
 
 function Remove-GeneratedPath {
     param([Parameter(Mandatory=$true)][string]$Path)
@@ -90,12 +92,62 @@ function Remove-OptionalHttp2Metadata {
     }
 }
 
+function Collect-ThirdPartyLicenses {
+    param([Parameter(Mandatory=$true)][string]$AppDir)
+    $outputDir = Join-Path $AppDir "third_party_licenses"
+    python $LicenseCollectorPath `
+        --constraints $ConstraintsPath `
+        --app-dir $AppDir `
+        --output-dir $outputDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "Third-party license collection failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Verify-DistributionCompliance {
+    param([Parameter(Mandatory=$true)][string]$AppDir)
+    foreach ($name in @("LICENSE", "NOTICE", "COMMERCIAL_LICENSE.md", "THIRD_PARTY_NOTICES.txt")) {
+        $path = Join-Path $AppDir $name
+        if (-not (Test-Path -LiteralPath $path)) {
+            throw "Required distribution notice missing: $path"
+        }
+    }
+
+    $licenseRoot = Join-Path $AppDir "third_party_licenses"
+    $requiredLicenseEntries = @(
+        "MANIFEST.txt",
+        "beautifulsoup4",
+        "soupsieve",
+        "openpyxl",
+        "et-xmlfile",
+        "requests",
+        "urllib3",
+        "charset-normalizer",
+        "idna",
+        "certifi",
+        "typing-extensions",
+        "pyinstaller",
+        "pyinstaller-hooks-contrib",
+        "python",
+        "tcl-tk"
+    )
+    foreach ($entry in $requiredLicenseEntries) {
+        $path = Join-Path $licenseRoot $entry
+        if (-not (Test-Path -LiteralPath $path)) {
+            throw "Required third-party license bundle entry missing: $path"
+        }
+    }
+}
+
 Set-Location $ProjectRoot
 Remove-GeneratedPath $BuildDir
 Remove-GeneratedPath $DistDir
 New-Item -ItemType Directory -Path $ReleaseDir -Force | Out-Null
 
 python -m PyInstaller $SpecPath --noconfirm --clean
+if ($LASTEXITCODE -ne 0) {
+    throw "PyInstaller failed with exit code $LASTEXITCODE."
+}
 
 $ExePath = Join-Path $DistDir "$AppDirName\GoogleScholarScraper.exe"
 if (-not (Test-Path -LiteralPath $ExePath)) {
@@ -104,6 +156,8 @@ if (-not (Test-Path -LiteralPath $ExePath)) {
 $AppDir = Join-Path $DistDir $AppDirName
 Remove-OptionalHttp2Metadata $AppDir
 Copy-DistributionNotices $AppDir
+Collect-ThirdPartyLicenses $AppDir
+Verify-DistributionCompliance $AppDir
 
 Compress-Archive -Path $AppDir -DestinationPath $PortablePath -Force
 if (-not (Test-Path -LiteralPath $PortablePath)) {
@@ -117,6 +171,9 @@ $checksums += "$portableHash  $PortableName"
 $InnoCompiler = Get-InnoCompiler
 if ($InnoCompiler -and -not $SkipInstaller) {
     & $InnoCompiler $InstallerScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "Inno Setup compilation failed with exit code $LASTEXITCODE."
+    }
     $InstallerPath = Join-Path $DistDir "installer\$InstallerName"
     if (-not (Test-Path -LiteralPath $InstallerPath)) {
         throw "Expected installer was not created: $InstallerPath"

--- a/scripts/collect_third_party_licenses.py
+++ b/scripts/collect_third_party_licenses.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from importlib import metadata
+from pathlib import Path
+
+
+RUNTIME_DISTRIBUTIONS = (
+    "beautifulsoup4",
+    "soupsieve",
+    "openpyxl",
+    "et-xmlfile",
+    "requests",
+    "urllib3",
+    "charset-normalizer",
+    "idna",
+    "certifi",
+    "typing-extensions",
+)
+
+BUNDLING_DISTRIBUTIONS = (
+    "pyinstaller",
+    "pyinstaller-hooks-contrib",
+)
+
+LEGAL_FILE_PREFIXES = (
+    "LICENSE",
+    "LICENCE",
+    "COPYING",
+    "NOTICE",
+    "AUTHORS",
+    "COPYRIGHT",
+)
+
+
+def canonical_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def read_constraints(path: Path) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        versions[canonical_name(name.strip())] = version.strip()
+    return versions
+
+
+def is_legal_file(relative_path: Path) -> bool:
+    upper_name = relative_path.name.upper()
+    if any(upper_name.startswith(prefix) for prefix in LEGAL_FILE_PREFIXES):
+        return True
+    return any(part.lower() in {"license", "licenses", "licence", "licences"} for part in relative_path.parts)
+
+
+def safe_destination_name(relative_path: Path, used_names: set[str]) -> str:
+    name = relative_path.name
+    if name not in used_names:
+        used_names.add(name)
+        return name
+
+    stem = relative_path.stem
+    suffix = relative_path.suffix
+    counter = 2
+    while True:
+        candidate = f"{stem}-{counter}{suffix}"
+        if candidate not in used_names:
+            used_names.add(candidate)
+            return candidate
+        counter += 1
+
+
+def collect_distribution_legal_files(
+    distribution_name: str,
+    expected_versions: dict[str, str],
+    output_root: Path,
+) -> tuple[str, list[str]]:
+    canonical = canonical_name(distribution_name)
+    expected_version = expected_versions.get(canonical)
+    if expected_version is None:
+        raise RuntimeError(f"No exact release constraint found for {distribution_name}.")
+
+    distribution = metadata.distribution(distribution_name)
+    actual_version = distribution.version
+    if actual_version != expected_version:
+        raise RuntimeError(
+            f"Version mismatch for {distribution_name}: expected {expected_version}, installed {actual_version}."
+        )
+
+    destination = output_root / canonical
+    destination.mkdir(parents=True, exist_ok=True)
+    copied: list[str] = []
+    used_names: set[str] = set()
+
+    for file_entry in distribution.files or ():
+        relative_path = Path(str(file_entry))
+        if not is_legal_file(relative_path):
+            continue
+        source = Path(distribution.locate_file(file_entry))
+        if not source.is_file():
+            continue
+        destination_name = safe_destination_name(relative_path, used_names)
+        shutil.copy2(source, destination / destination_name)
+        copied.append(destination_name)
+
+    if not copied:
+        raise RuntimeError(
+            f"No license, notice, copyright, or author file was found in the installed {distribution_name} {actual_version} distribution."
+        )
+
+    return actual_version, sorted(copied)
+
+
+def copy_python_license(output_root: Path) -> list[str]:
+    candidates = (
+        Path(sys.base_prefix) / "LICENSE.txt",
+        Path(sys.base_prefix) / "LICENSE",
+        Path(sys.prefix) / "LICENSE.txt",
+        Path(sys.prefix) / "LICENSE",
+    )
+    destination = output_root / "python"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            target = destination / candidate.name
+            shutil.copy2(candidate, target)
+            return [target.name]
+
+    raise RuntimeError("Could not locate the Python runtime license in the active release-build interpreter.")
+
+
+def copy_tcl_tk_licenses(app_dir: Path, output_root: Path) -> list[str]:
+    internal_dir = app_dir / "_internal"
+    candidates = sorted(
+        {
+            *internal_dir.glob("_tk_data/**/license.terms"),
+            *internal_dir.glob("_tcl_data/**/license.terms"),
+        }
+    )
+    if not candidates:
+        raise RuntimeError("Could not locate Tcl/Tk license.terms in the packaged application.")
+
+    destination = output_root / "tcl-tk"
+    destination.mkdir(parents=True, exist_ok=True)
+    copied: list[str] = []
+    used_names: set[str] = set()
+    for candidate in candidates:
+        base_name = "license.terms"
+        destination_name = safe_destination_name(Path(base_name), used_names)
+        shutil.copy2(candidate, destination / destination_name)
+        copied.append(destination_name)
+    return copied
+
+
+def write_manifest(
+    output_root: Path,
+    collected: list[tuple[str, str, list[str]]],
+    python_files: list[str],
+    tcl_tk_files: list[str],
+) -> None:
+    lines = [
+        "Google Scholar Scraper V2.0.1 third-party license bundle",
+        "",
+        "This directory was assembled from the exact constrained release-build environment.",
+        "Each listed file is copied from the installed distribution metadata or packaged runtime.",
+        "",
+    ]
+    for distribution_name, version, files in collected:
+        lines.append(f"{distribution_name} {version}")
+        for file_name in files:
+            lines.append(f"  - {canonical_name(distribution_name)}/{file_name}")
+        lines.append("")
+
+    lines.append("Python runtime")
+    for file_name in python_files:
+        lines.append(f"  - python/{file_name}")
+    lines.append("")
+
+    lines.append("Tcl/Tk runtime")
+    for file_name in tcl_tk_files:
+        lines.append(f"  - tcl-tk/{file_name}")
+    lines.append("")
+
+    (output_root / "MANIFEST.txt").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect exact third-party license files for a Windows release bundle.")
+    parser.add_argument("--constraints", type=Path, required=True)
+    parser.add_argument("--app-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    constraints = args.constraints.resolve()
+    app_dir = args.app_dir.resolve()
+    output_root = args.output_dir.resolve()
+
+    if not constraints.is_file():
+        raise RuntimeError(f"Constraints file not found: {constraints}")
+    if not app_dir.is_dir():
+        raise RuntimeError(f"Packaged application directory not found: {app_dir}")
+
+    if output_root.exists():
+        shutil.rmtree(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    expected_versions = read_constraints(constraints)
+    collected: list[tuple[str, str, list[str]]] = []
+    for distribution_name in (*RUNTIME_DISTRIBUTIONS, *BUNDLING_DISTRIBUTIONS):
+        version, files = collect_distribution_legal_files(distribution_name, expected_versions, output_root)
+        collected.append((distribution_name, version, files))
+
+    python_files = copy_python_license(output_root)
+    tcl_tk_files = copy_tcl_tk_licenses(app_dir, output_root)
+    write_manifest(output_root, collected, python_files, tcl_tk_files)
+
+    print(f"Collected third-party licenses in: {output_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -17,6 +17,7 @@ class PackagingMetadataTests(unittest.TestCase):
         self.assertEqual(google_scholar_scraper.__version__, "2.0.1")
         self.assertIn('version = "2.0.1"', pyproject)
         self.assertIn('requires-python = ">=3.10"', pyproject)
+        self.assertIn('"requests>=2.33,<3"', pyproject)
 
     def test_gui_entrypoint_is_import_safe(self) -> None:
         self.assertTrue(callable(main))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,3 +1,5 @@
+import csv
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -20,9 +22,6 @@ class PackagingMetadataTests(unittest.TestCase):
         self.assertTrue(callable(main))
 
     def test_packaging_smoke_writes_excel_and_csv_without_starting_gui(self) -> None:
-        import tempfile
-        import csv
-
         with tempfile.TemporaryDirectory() as temp_dir:
             run_packaging_smoke(Path(temp_dir))
 
@@ -35,20 +34,20 @@ class PackagingMetadataTests(unittest.TestCase):
             self.assertEqual(rows[0]["Relevance Score"], "88.8")
             self.assertEqual(rows[1]["Relevance Score"], "")
 
-    def test_pyinstaller_spec_uses_windowed_onedir_identity(self) -> None:
+    def test_pyinstaller_spec_uses_windowed_onedir_identity_without_duplicate_notice_datas(self) -> None:
         spec = (PROJECT_ROOT / "packaging" / "pyinstaller" / "GoogleScholarScraper.spec").read_text(encoding="utf-8")
 
         self.assertIn('entrypoint = src_path / "google_scholar_scraper" / "__main__.py"', spec)
         self.assertIn("console=False", spec)
         self.assertIn('name="Google-Scholar-Scraper-v2.0.1"', spec)
-        self.assertIn("THIRD_PARTY_NOTICES.txt", spec)
-        self.assertIn("COMMERCIAL_LICENSE.md", spec)
+        self.assertIn("datas=[]", spec)
+        self.assertNotIn("distribution_documents", spec)
         self.assertIn('excludes=["tests", *excluded_optional_modules]', spec)
         self.assertIn('"h2"', spec)
         self.assertIn('"pandas"', spec)
         self.assertIn('"torch"', spec)
 
-    def test_build_script_uses_expected_artifact_names_and_guarded_cleaning(self) -> None:
+    def test_build_script_uses_expected_artifact_names_and_license_collection(self) -> None:
         script = (PROJECT_ROOT / "scripts" / "build_windows.ps1").read_text(encoding="utf-8")
 
         self.assertIn("Google-Scholar-Scraper-v$Version-Portable-Windows-x64.zip", script)
@@ -56,10 +55,33 @@ class PackagingMetadataTests(unittest.TestCase):
         self.assertIn("Refusing to remove path outside repository", script)
         self.assertIn('"build", "dist"', script)
         self.assertIn("System.Security.Cryptography.SHA256", script)
-        self.assertIn("Copy-DistributionNotices", script)
-        self.assertIn("Remove-OptionalHttp2Metadata", script)
-        self.assertIn("THIRD_PARTY_NOTICES.txt", script)
+        self.assertIn("Collect-ThirdPartyLicenses", script)
+        self.assertIn("Verify-DistributionCompliance", script)
+        self.assertIn("collect_third_party_licenses.py", script)
+        self.assertIn("third_party_licenses", script)
         self.assertNotIn("installer/$InstallerName", script)
+
+    def test_third_party_license_collector_covers_runtime_and_packaging_components(self) -> None:
+        collector = (PROJECT_ROOT / "scripts" / "collect_third_party_licenses.py").read_text(encoding="utf-8")
+
+        for distribution_name in (
+            "beautifulsoup4",
+            "soupsieve",
+            "openpyxl",
+            "et-xmlfile",
+            "requests",
+            "urllib3",
+            "charset-normalizer",
+            "idna",
+            "certifi",
+            "typing-extensions",
+            "pyinstaller",
+            "pyinstaller-hooks-contrib",
+        ):
+            self.assertIn(f'"{distribution_name}"', collector)
+        self.assertIn("copy_python_license", collector)
+        self.assertIn("copy_tcl_tk_licenses", collector)
+        self.assertIn("MANIFEST.txt", collector)
 
     def test_inno_setup_definition_uses_per_user_installer_metadata(self) -> None:
         iss = (PROJECT_ROOT / "installer" / "GoogleScholarScraper.iss").read_text(encoding="utf-8")
@@ -69,29 +91,35 @@ class PackagingMetadataTests(unittest.TestCase):
         self.assertIn("PrivilegesRequired=lowest", iss)
         self.assertIn("Google-Scholar-Scraper-v2.0.1-Setup-Windows-x64", iss)
 
-    def test_release_licensing_and_notice_files_are_present(self) -> None:
+    def test_release_licensing_notice_and_release_note_files_are_present(self) -> None:
         license_text = (PROJECT_ROOT / "LICENSE").read_text(encoding="utf-8")
         notice = (PROJECT_ROOT / "NOTICE").read_text(encoding="utf-8")
         commercial = (PROJECT_ROOT / "COMMERCIAL_LICENSE.md").read_text(encoding="utf-8")
         third_party = (PROJECT_ROOT / "THIRD_PARTY_NOTICES.txt").read_text(encoding="utf-8")
+        release_notes = (PROJECT_ROOT / "docs" / "RELEASE_NOTES_V2.0.1.md").read_text(encoding="utf-8")
 
         self.assertIn("PolyForm Noncommercial License 1.0.0", license_text)
         self.assertIn("Mahdi Navaei", notice)
         self.assertIn("Commercial use requires a separate written commercial license", commercial)
         self.assertIn("beautifulsoup4 4.14.3", third_party)
-        self.assertIn("PyInstaller 6.20.0", third_party)
+        self.assertIn("requests 2.33.0", third_party)
+        self.assertIn("urllib3 2.7.0", third_party)
+        self.assertIn("idna 3.15", third_party)
+        self.assertIn("Google Scholar Scraper V2.0.1", release_notes)
 
-    def test_windows_workflow_builds_installer_and_uploads_artifacts_without_release_publish(self) -> None:
+    def test_windows_workflow_builds_installer_collects_licenses_and_uploads_artifacts_without_release_publish(self) -> None:
         workflow = (PROJECT_ROOT / ".github" / "workflows" / "build-windows.yml").read_text(encoding="utf-8")
 
         self.assertIn("workflow_dispatch", workflow)
+        self.assertIn("pull_request", workflow)
         self.assertIn("choco install innosetup", workflow)
         self.assertIn("Build Windows Installer", workflow)
-        self.assertIn("Copy distribution notices", workflow)
-        self.assertIn("h2-*.dist-info", workflow)
+        self.assertIn("Collect exact third-party licenses", workflow)
+        self.assertIn("Verify packaged executable and distribution compliance", workflow)
         self.assertIn("Installer install-launch-export-uninstall smoke", workflow)
         self.assertIn("unins000.exe", workflow)
         self.assertIn("constraints/release-2.0.1.txt", workflow)
+        self.assertIn("third_party_licenses", workflow)
         self.assertIn("actions/upload-artifact@v4", workflow)
         self.assertNotIn("softprops/action-gh-release", workflow)
 
@@ -99,7 +127,9 @@ class PackagingMetadataTests(unittest.TestCase):
         constraints = (PROJECT_ROOT / "constraints" / "release-2.0.1.txt").read_text(encoding="utf-8")
 
         self.assertIn("beautifulsoup4==4.14.3", constraints)
-        self.assertIn("requests==2.32.5", constraints)
+        self.assertIn("requests==2.33.0", constraints)
+        self.assertIn("urllib3==2.7.0", constraints)
+        self.assertIn("idna==3.15", constraints)
         self.assertIn("pyinstaller==6.20.0", constraints)
 
 

--- a/third_party_licenses/README.md
+++ b/third_party_licenses/README.md
@@ -1,0 +1,12 @@
+# Third Party Licenses
+
+This directory contains license texts for third-party dependencies included in
+release distributions.
+
+The files in this directory must correspond to the exact versions pinned in:
+
+- constraints/release-2.0.1.txt
+- THIRD_PARTY_NOTICES.txt
+
+Application code licensing remains documented in LICENSE, NOTICE, and
+COMMERCIAL_LICENSE.md.

--- a/third_party_licenses/README.md
+++ b/third_party_licenses/README.md
@@ -24,5 +24,6 @@ The Windows build fails if any required component lacks an identifiable legal
 file, if an installed dependency version differs from the release constraints,
 or if the Python or Tcl/Tk runtime license cannot be collected.
 
-Application code licensing remains documented in `LICENSE`, `NOTICE`, and
-`COMMERCIAL_LICENSE.md`.
+The component summary and expected versions are documented in
+`THIRD_PARTY_NOTICES.txt`. Application code licensing remains documented in
+`LICENSE`, `NOTICE`, and `COMMERCIAL_LICENSE.md`.

--- a/third_party_licenses/README.md
+++ b/third_party_licenses/README.md
@@ -20,5 +20,9 @@ plus per-component legal files. These generated files are release artifacts and
 are not committed manually, which avoids stale license text drifting away from
 the exact dependency versions used to build the release.
 
+The Windows build fails if any required component lacks an identifiable legal
+file, if an installed dependency version differs from the release constraints,
+or if the Python or Tcl/Tk runtime license cannot be collected.
+
 Application code licensing remains documented in `LICENSE`, `NOTICE`, and
 `COMMERCIAL_LICENSE.md`.

--- a/third_party_licenses/README.md
+++ b/third_party_licenses/README.md
@@ -1,12 +1,24 @@
 # Third Party Licenses
 
-This directory contains license texts for third-party dependencies included in
-release distributions.
+This source-tree directory documents the generated third-party license bundle used
+for Windows releases.
 
-The files in this directory must correspond to the exact versions pinned in:
+The actual legal files are collected during the release build by:
 
-- constraints/release-2.0.1.txt
-- THIRD_PARTY_NOTICES.txt
+`scripts/collect_third_party_licenses.py`
 
-Application code licensing remains documented in LICENSE, NOTICE, and
-COMMERCIAL_LICENSE.md.
+The collector copies license, notice, copyright, and author files from the exact
+installed distributions constrained by `constraints/release-2.0.1.txt`. It also
+copies the active Python runtime license and the Tcl/Tk license shipped with the
+packaged application.
+
+The generated Windows portable and installer layouts contain:
+
+`third_party_licenses/MANIFEST.txt`
+
+plus per-component legal files. These generated files are release artifacts and
+are not committed manually, which avoids stale license text drifting away from
+the exact dependency versions used to build the release.
+
+Application code licensing remains documented in `LICENSE`, `NOTICE`, and
+`COMMERCIAL_LICENSE.md`.


### PR DESCRIPTION
## Summary

Final cleanup for V2.0.1 release candidate.

Changes:
- Added V2.0.1 release notes.
- Improved third-party notices wording and release distribution guidance.
- Added third_party_licenses documentation location.

This PR keeps V2.0.0 assets untouched and prepares the remaining release governance items.