### PR TITLE
Add controlled V2.0.1 publication gate

### DIFF
--- a/.github/workflows/publish-v2.0.1.yml
+++ b/.github/workflows/publish-v2.0.1.yml
@@ -1,0 +1,156 @@
+name: Publish V2.0.1
+
+on:
+  workflow_run:
+    workflows:
+      - Build Windows Artifacts
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      startsWith(github.event.workflow_run.head_commit.message, 'Publish Google Scholar Scraper V2.0.1')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    env:
+      TAG_NAME: v2.0.1
+      RELEASE_TITLE: Google Scholar Scraper V2.0.1
+      ARTIFACT_NAME: google-scholar-scraper-v2.0.1-windows-artifacts
+      PORTABLE_NAME: Google-Scholar-Scraper-v2.0.1-Portable-Windows-x64.zip
+      INSTALLER_NAME: Google-Scholar-Scraper-v2.0.1-Setup-Windows-x64.exe
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      BUILD_RUN_ID: ${{ github.event.workflow_run.id }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out exact release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Verify release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          grep -F '__version__ = "2.0.1"' src/google_scholar_scraper/__init__.py
+          grep -F 'version = "2.0.1"' pyproject.toml
+          test -f docs/RELEASE_NOTES_V2.0.1.md
+
+      - name: Download exact successful Windows build artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run download "$BUILD_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$ARTIFACT_NAME" \
+            --dir release-assets
+
+      - name: Stage and verify release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p publish
+          cp "release-assets/release/$PORTABLE_NAME" "publish/$PORTABLE_NAME"
+          cp "release-assets/installer/$INSTALLER_NAME" "publish/$INSTALLER_NAME"
+          cp "release-assets/release/SHA256SUMS.txt" publish/SHA256SUMS.txt
+          test -s "publish/$PORTABLE_NAME"
+          test -s "publish/$INSTALLER_NAME"
+          test -s publish/SHA256SUMS.txt
+          cd publish
+          sha256sum -c SHA256SUMS.txt
+
+      - name: Verify tag and release preconditions
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin --tags --force
+          if git rev-parse -q --verify "refs/tags/$TAG_NAME" >/dev/null; then
+            existing_target="$(git rev-list -n 1 "$TAG_NAME")"
+            if [ "$existing_target" != "$RELEASE_SHA" ]; then
+              echo "Existing $TAG_NAME points to $existing_target instead of $RELEASE_SHA." >&2
+              exit 1
+            fi
+            echo "TAG_ALREADY_EXISTS=true" >> "$GITHUB_ENV"
+          else
+            echo "TAG_ALREADY_EXISTS=false" >> "$GITHUB_ENV"
+          fi
+
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release $TAG_NAME already exists; refusing to overwrite it." >&2
+            exit 1
+          fi
+
+      - name: Create annotated release tag
+        if: env.TAG_ALREADY_EXISTS != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG_NAME" "$RELEASE_SHA" -m "$RELEASE_TITLE"
+          git push origin "refs/tags/$TAG_NAME"
+
+      - name: Verify immutable tag target
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin --tags --force
+          test "$(git rev-list -n 1 "$TAG_NAME")" = "$RELEASE_SHA"
+
+      - name: Publish stable GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$TAG_NAME" \
+            "publish/$PORTABLE_NAME" \
+            "publish/$INSTALLER_NAME" \
+            publish/SHA256SUMS.txt \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$RELEASE_TITLE" \
+            --notes-file docs/RELEASE_NOTES_V2.0.1.md \
+            --verify-tag
+
+      - name: Verify published release and public assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata="$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json tagName,isDraft,isPrerelease,url)"
+          echo "$metadata"
+          test "$(echo "$metadata" | jq -r .tagName)" = "$TAG_NAME"
+          test "$(echo "$metadata" | jq -r .isDraft)" = "false"
+          test "$(echo "$metadata" | jq -r .isPrerelease)" = "false"
+
+          mkdir -p public-verify
+          gh release download "$TAG_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir public-verify \
+            --pattern "$PORTABLE_NAME" \
+            --pattern "$INSTALLER_NAME" \
+            --pattern SHA256SUMS.txt
+          cd public-verify
+          sha256sum -c SHA256SUMS.txt
+
+      - name: Write release summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_url="$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json url --jq .url)"
+          {
+            echo "## V2.0.1 published and verified"
+            echo
+            echo "- Source commit: \`$RELEASE_SHA\`"
+            echo "- Tag: \`$TAG_NAME\`"
+            echo "- Release: $release_url"
+            echo "- Public release assets passed SHA-256 verification."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a one-time, version-specific publication workflow for V2.0.1.

The workflow runs only after the existing Windows build succeeds on a push to `main` whose commit message starts with `Publish Google Scholar Scraper V2.0.1`.

It then:
- downloads the exact artifact from that successful build run,
- verifies `SHA256SUMS.txt`,
- creates an annotated `v2.0.1` tag at the exact built commit,
- publishes the stable GitHub Release using `docs/RELEASE_NOTES_V2.0.1.md`,
- downloads the published assets again and verifies their hashes.

V2.0.0 is not modified.